### PR TITLE
feat(components): 弹窗关闭时清空表单数据

### DIFF
--- a/packages/components/dialog-form/src/index.vue
+++ b/packages/components/dialog-form/src/index.vue
@@ -124,6 +124,10 @@ watch(
   () => props.visible,
   val => {
     subVisible.value = val
+
+    if (val === false) {
+      computedFormInstance.value.resetFields()
+    }
   },
   {
     immediate: true


### PR DESCRIPTION
新增或者编辑完成后关闭弹窗需要手动清除数据.不然下一次打开新增弹窗会保留上一次的数据.组件内部主动清除会不会更好用一点