### PR TITLE
style(components): [search] Fixed the problem of the operation button position when the search component `label-position` is top

### DIFF
--- a/packages/play/src/views/search.vue
+++ b/packages/play/src/views/search.vue
@@ -1,21 +1,44 @@
 <template>
   <el-card>
-    <PlusSearch
-      v-model="state"
-      :columns="columns"
-      :show-number="4"
-      @change="handleChange"
-      @search="handleSearch"
-      @reset="handleReset"
-      @collapse="onCollapse"
-    />
+    <el-space direction="vertical" alignment="normal" style="display: flex">
+      <el-space>
+        <PlusRadio v-model="labelPositionState.value" :options="labelPositionState.options" />
+        <el-input-number v-model="showNumber" :min="1" />
+      </el-space>
+
+      <PlusSearch
+        v-model="state"
+        :columns="columns"
+        :show-number="showNumber"
+        :label-position="labelPositionState.value"
+        @change="handleChange"
+        @search="handleSearch"
+        @reset="handleReset"
+        @collapse="onCollapse"
+      />
+    </el-space>
   </el-card>
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue'
+import { ref, computed, reactive } from 'vue'
 import type { PlusColumn } from '@plus-pro-components/types'
+import type { OptionsRow, RecordType } from 'plus-pro-components'
+type State = {
+  options: OptionsRow<RecordType>[]
+  value: string
+}
 
+const labelPositionState = reactive<State>({
+  options: [
+    { label: 'Left', value: 'left' },
+    { label: 'Right', value: 'right' },
+    { label: 'Top', value: 'top' }
+  ],
+  value: 'left'
+})
+
+const showNumber = ref<number>(4)
 const state = ref({
   status: '0',
   time: new Date().toString()

--- a/packages/theme-chalk/src/search.scss
+++ b/packages/theme-chalk/src/search.scss
@@ -3,6 +3,7 @@
 
 @include b(search) {
   .#{$plus-namespace + -form__row} {
+    flex: 1;
     row-gap: 18px;
   }
 
@@ -23,6 +24,7 @@
     margin-bottom: 0;
     display: flex;
     align-items: flex-start;
+    align-self: flex-end;
     justify-content: flex-end;
 
     &.#{$el-namespace + -form-item} {


### PR DESCRIPTION
修复search组件label-position 在 top 情况下，操作按钮位置不正确问题

![image](https://github.com/user-attachments/assets/14e09b0c-83cd-4015-8393-bb50c1308476)

更改后：
![image](https://github.com/user-attachments/assets/421b79c0-66b9-453b-b938-84f2e31b7de0)
