### PR TITLE
feat: search组件增加props retractText expandText 默认使用组件为英文，主框架不引入i18n无法自定…

### DIFF
--- a/packages/components/search/src/index.vue
+++ b/packages/components/search/src/index.vue
@@ -60,7 +60,7 @@
             href="javaScript:;"
             @click="handleUnfold"
           >
-            {{ isShowUnfold ? t('plus.search.retract') : t('plus.search.expand') }}
+            {{ isShowUnfold ? retractText || t('plus.search.retract') : expandText || t('plus.search.expand') }}
             <el-icon>
               <ArrowUp v-if="isShowUnfold" />
               <ArrowDown v-else />
@@ -102,6 +102,8 @@ const props = withDefaults(defineProps<PlusSearchProps>(), {
   searchLoading: false,
   searchText: '',
   resetText: '',
+  retractText: '',
+  expandText: '',
   inline: true,
   showNumber: 2,
   labelPosition: undefined,

--- a/packages/components/search/src/type.ts
+++ b/packages/components/search/src/type.ts
@@ -12,6 +12,8 @@ export type PlusSearchSelfProps = {
   hasUnfold?: boolean
   searchText?: string
   resetText?: string
+  retractText?: string
+  expandText?: string
   searchLoading?: boolean
   inline?: boolean
   showNumber?: number


### PR DESCRIPTION
plus-pro-components i18n 默认为英文，由于基座未使用i18n，无法修改语言。给search组件展开和收起按钮增加自定义名称功能。