### PR TITLE
fix(components): :bug: valueType: 'copy' in multi-level fields, clipb…

### DIFF
--- a/packages/components/display-item/src/index.vue
+++ b/packages/components/display-item/src/index.vue
@@ -541,7 +541,7 @@ const copy = (data: string) => {
 }
 
 const handelClickCopy = (item: PlusColumn, row: RecordType) => {
-  copy(row[item.prop])
+  copy(formatterValue.value)
   row.isCopy = true
   setTimeout(() => {
     row.isCopy = false


### PR DESCRIPTION
…oard value is undefined

valueType: "copy" 在多级字段时复制失败，剪切板值为 undefined  #254