### PR TITLE
fix(PlusDrawerForm): prevent onCancel from being triggered twice(#266)

### DIFF
--- a/packages/components/drawer-form/src/index.vue
+++ b/packages/components/drawer-form/src/index.vue
@@ -8,7 +8,7 @@
     :close-on-click-modal="false"
     :close-on-press-escape="false"
     v-bind="$attrs"
-    @close="handleCancel"
+    @close="handleClose"
   >
     <template v-if="$slots['drawer-header']" #header>
       <slot name="drawer-header" />
@@ -191,10 +191,22 @@ const handleConfirm = async () => {
   }
 }
 
-const handleCancel = () => {
-  subVisible.value = false
+/*
+ * 处理 Drawer 关闭事件
+ * 调用 handleCancel 关闭 Drawer，并触发响应的事件
+ */
+const handleClose = () => {
+  handleCancel()
   emit('update:visible', subVisible.value)
   emit('cancel')
+}
+
+/*
+ * 关闭 Drawer
+ * 仅更新 subVisible 状态，同时会自动触发 el-drawer 的 close 事件
+ */
+const handleCancel = () => {
+  subVisible.value = false
 }
 
 defineExpose({


### PR DESCRIPTION
我修复了 https://github.com/plus-pro-components/plus-pro-components/issues/266

> 问题原因：点击取消按钮，组件状态变为 false，el-drawer 组件会自动调用一次 `@close` 事件，导致触发了两次，我把函数分开拆分为两个，避免了这个问题。

https://github.com/user-attachments/assets/5781a065-d38d-4d38-a399-5a9b3e7bf052

---

代码在浏览器运行没问题，我尝试添加测试文件，但是没成功，卡在了调用 `.trigger('click');` 没生效，我的测试文件如下：

```
test('@cancel event triggered by clicking default cancel button', async () => {
  const visible = ref(false);
  const values = ref<FieldValues>({});
  const onCancel = vi.fn(); // 使用 vitest 的 mock 函数

  const wrapper = mount(
    () => (
      <DrawerForm
        visible={visible.value}
        modelValue={values.value}
        form={{ columns }}
        onCancel={onCancel} // 使用 onCancel 绑定事件
      />
    ),
    {
      global: {
        plugins: [ElementPlus],
      },
    }
  );

  visible.value = true;
  await nextTick();

  // 没生效
  await wrapper.find('.el-drawer__close-btn').trigger('click');

  // 验证 @cancel 事件是否被调用一次
  expect(onCancel).toHaveBeenCalledTimes(1);
});
```

本来还有两个测试文件，但是第一个没添加成功，就不粘贴代码了，你可以直接修改我的代码添加测试问题🙏。