### PR TITLE
fix(steps-form): prevent premature submit on last step navigation

### DIFF
--- a/packages/components/steps-form/src/index.vue
+++ b/packages/components/steps-form/src/index.vue
@@ -149,7 +149,7 @@ const next = (values: FieldValues) => {
   emit('next', active.value, values, allValues.value);
 
   // Check if moving from last step to completion
-  if (currentActive === props.data.length - 1 && active.value === props.data.length) {
+  if (currentActive === props.data.length && active.value === props.data.length) {
     emit('submit', active.value, values, allValues.value);
   }
 }

--- a/packages/components/steps-form/src/index.vue
+++ b/packages/components/steps-form/src/index.vue
@@ -139,12 +139,18 @@ const pre = () => {
 
 // 下一步
 const next = (values: FieldValues) => {
-  if (active.value++ > props.data.length - 1) active.value = props.data.length
-  emit('update:modelValue', active.value)
-  emit('next', active.value, values, allValues.value)
+  // Save current active value for comparison
+  const currentActive = active.value;
 
-  if (active.value === props.data.length) {
-    emit('submit', active.value, values, allValues.value)
+  // Update active value, ensuring it doesn't exceed max index
+  active.value = Math.min(currentActive + 1, props.data.length);
+
+  emit('update:modelValue', active.value);
+  emit('next', active.value, values, allValues.value);
+
+  // Check if moving from last step to completion
+  if (currentActive === props.data.length - 1 && active.value === props.data.length) {
+    emit('submit', active.value, values, allValues.value);
   }
 }
 </script>

--- a/packages/play/src/views/steps-form.vue
+++ b/packages/play/src/views/steps-form.vue
@@ -1,6 +1,13 @@
 <template>
   <!-- @vue-ignore -->
-  <PlusStepsForm v-model="active" direction="vertical" :space="120" :data="stepForm" @next="next">
+  <PlusStepsForm
+    v-model="active"
+    direction="vertical"
+    :space="120"
+    :data="stepForm"
+    @next="next"
+    @submit="submit"
+  >
     <template #title="{ title }">{{ title }}</template>
   </PlusStepsForm>
 </template>
@@ -176,6 +183,9 @@ const stepForm = ref([
 const active = ref(1)
 const next = (actives: number, values: any) => {
   active.value = actives
-  console.log(actives, values, stepForm.value)
+  console.log('next', actives, values, stepForm.value)
+}
+const submit = (actives: number, values: any) => {
+  console.log('submit', actives, values, stepForm.value)
 }
 </script>


### PR DESCRIPTION
问题复现：

在一个三步表单（data.length = 3，索引为 1, 2, 3）中：

第一步（active.value = 1）→ 点击 下一步  → 进入第二步（active.value = 2）

第二步（active.value = 2）→ 点击 下一步 → 按照原逻辑，active.value = 3）

此时 active.value === props.data.length（3 === 3），直接触发了 submit，导致：

用户看不到第三步（索引 2）的表单内容