### PR TITLE
feat(pagination): add center alignment support and examples

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -8,11 +8,21 @@ pagination/basic
 
 :::
 
+## 对齐方式
+
+支持 `left`、`right`、`center` 三种对齐方式。
+
+:::demo
+
+pagination/align
+
+:::
+
 ## 左右侧内容 自定义
 
 <el-tag>v0.0.2</el-tag>
 
-`align` 属性默认是 `right`，插槽 `pagination-left` 默认生效。要使用`pagination-right` 插槽，需要设置`align` 属性为 `left`。
+`align` 属性默认是 `right`，插槽 `pagination-left` 默认生效。要使用`pagination-right` 插槽，需要设置`align` 属性为 `left`。设置 `align` 为 `center` 时分页器将居中显示，且左右两个插槽都可使用<el-tag>v0.1.28</el-tag>。
 :::demo
 
 pagination/slot
@@ -25,7 +35,7 @@ pagination/slot
 
 | 名称                    | 说明     | 类型                                                      | 默认值                                          | 是否必须 |
 | ----------------------- | -------- | --------------------------------------------------------- | ----------------------------------------------- | -------- |
-| `align`                 | 对齐方式 | `string` <docs-tip content="'left' / 'right'"></docs-tip> | `right`                                         | 否       |
+| `align`                 | 对齐方式 | `string` <docs-tip content="'left' / 'right' / 'center'"></docs-tip> | `right`                                         | 否       |
 | `model-value / v-model` | 分页值   | `object` [PageInfo](/components/type.html#pageinfo)       | `{  page: 1,pageSize: 10}`                      | 否       |
 | `total`                 | 总数     | `number`                                                  | `0`                                             | 否       |
 | `pageSizeList`          | 分页列表 | `array` <docs-tip content="number[]"></docs-tip>          | `[10, 20, 30, 40, 50, 100, 200, 300, 400, 500]` | 否       |
@@ -54,5 +64,5 @@ el-pagination 的其他事件的支持写法 如 prev-click，如下示例
 
 | 插槽名                                    | 说明                                                    |
 | ----------------------------------------- | ------------------------------------------------------- |
-| `pagination-left`<el-tag>v0.0.2</el-tag>  | 分页器左侧内容 （默认生效，`align` 属性默认是 `right`） |
-| `pagination-right`<el-tag>v0.0.2</el-tag> | 分页器右侧内容 （`align` 属性是 `left`时生效）          |
+| `pagination-left`<el-tag>v0.0.2</el-tag>  | 分页器左侧内容 （`align` 为 `right` 或 `center` 时生效） |
+| `pagination-right`<el-tag>v0.0.2</el-tag> | 分页器右侧内容 （`align` 为 `left` 或 `center` 时生效）          |

--- a/docs/examples/pagination/align.vue
+++ b/docs/examples/pagination/align.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <h4>右对齐（默认）</h4>
+    <PlusPagination v-model="page" :total="100" />
+
+    <h4>左对齐</h4>
+    <PlusPagination v-model="page" :total="100" align="left" />
+
+    <h4>居中对齐</h4>
+    <PlusPagination v-model="page" :total="100" align="center" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+const page = ref()
+</script>
+
+<style scoped>
+h4 {
+  margin: 20px 0 10px 0;
+  font-size: 14px;
+  color: #606266;
+}
+</style>

--- a/docs/examples/pagination/slot.vue
+++ b/docs/examples/pagination/slot.vue
@@ -1,15 +1,32 @@
 <template>
-  <PlusPagination v-model="page" :total="100" :small="true">
-    <template #pagination-left>
-      <span class="fs-12">总计:59.49</span>
-    </template>
-  </PlusPagination>
+  <div>
+    <h4>右对齐 + 左侧插槽</h4>
+    <PlusPagination v-model="page" :total="100" :small="true">
+      <template #pagination-left>
+        <span class="fs-12">插槽内容</span>
+      </template>
+    </PlusPagination>
 
-  <PlusPagination v-model="page" :total="100" align="left" :small="true">
-    <template #pagination-right>
-      <span class="fs-12">总计:59.49</span>
-    </template>
-  </PlusPagination>
+    <h4>左对齐 + 右侧插槽</h4>
+    <PlusPagination v-model="page" :total="100" align="left" :small="true">
+      <template #pagination-right>
+        <span class="fs-12">插槽内容</span>
+      </template>
+    </PlusPagination>
+
+    <h4>居中对齐（无插槽）</h4>
+    <PlusPagination v-model="page" :total="100" align="center" :small="true" />
+
+    <h4>居中对齐 + 左右插槽</h4>
+    <PlusPagination v-model="page" :total="100" align="center" :small="true">
+      <template #pagination-left>
+        <span class="fs-12">左侧内容</span>
+      </template>
+      <template #pagination-right>
+        <span class="fs-12">右侧内容</span>
+      </template>
+    </PlusPagination>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -20,5 +37,11 @@ const page = ref()
 <style lang="scss" scoped>
 .fs-12 {
   font-size: 12px;
+}
+
+h4 {
+  margin: 20px 0 10px 0;
+  font-size: 14px;
+  color: #606266;
 }
 </style>

--- a/packages/components/pagination/__tests__/pagination.test.tsx
+++ b/packages/components/pagination/__tests__/pagination.test.tsx
@@ -73,4 +73,72 @@ describe('pagination/index.vue', () => {
     await nextTick()
     expect(wrapper1.find('.plus-pagination').text()).includes('pagination-right')
   })
+
+  test('center align with both slots test', async () => {
+    const total = 100
+    const pageInfo = ref()
+    const centerWrapper = mount(
+      () => (
+        <Pagination
+          total={total}
+          align="center"
+          modelValue={pageInfo.value}
+          v-slots={{
+            'pagination-left': () => 'left-content',
+            'pagination-right': () => 'right-content'
+          }}
+        ></Pagination>
+      ),
+      {
+        global: {
+          plugins: [ElementPlus]
+        }
+      }
+    )
+    await nextTick()
+    expect(centerWrapper.find('.plus-pagination').text()).includes('left-content')
+    expect(centerWrapper.find('.plus-pagination').text()).includes('right-content')
+    expect(centerWrapper.find('.plus-pagination').classes()).toContain('plus-pagination--center')
+  })
+
+  test('align test', async () => {
+    const total = 100
+    const pageInfo = ref()
+
+    // Test center align
+    const centerWrapper = mount(
+      () => <Pagination total={total} align="center" modelValue={pageInfo.value}></Pagination>,
+      {
+        global: {
+          plugins: [ElementPlus]
+        }
+      }
+    )
+    await nextTick()
+    expect(centerWrapper.find('.plus-pagination').classes()).toContain('plus-pagination--center')
+
+    // Test left align
+    const leftWrapper = mount(
+      () => <Pagination total={total} align="left" modelValue={pageInfo.value}></Pagination>,
+      {
+        global: {
+          plugins: [ElementPlus]
+        }
+      }
+    )
+    await nextTick()
+    expect(leftWrapper.find('.plus-pagination').classes()).toContain('plus-pagination--left')
+
+    // Test right align (default)
+    const rightWrapper = mount(
+      () => <Pagination total={total} align="right" modelValue={pageInfo.value}></Pagination>,
+      {
+        global: {
+          plugins: [ElementPlus]
+        }
+      }
+    )
+    await nextTick()
+    expect(rightWrapper.find('.plus-pagination').classes()).toContain('plus-pagination--right')
+  })
 })

--- a/packages/components/pagination/src/index.vue
+++ b/packages/components/pagination/src/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="plus-pagination">
-    <slot v-if="align === 'right'" name="pagination-left">
+  <div class="plus-pagination" :class="[`plus-pagination--${align}`]">
+    <slot v-if="align === 'right' || align === 'center'" name="pagination-left">
       <span />
     </slot>
 
@@ -15,7 +15,10 @@
       @size-change="handleSizeChange"
       @current-change="handleCurrentChange"
     />
-    <slot v-if="align === 'left'" name="pagination-right"> <span /></slot>
+
+    <slot v-if="align === 'left' || align === 'center'" name="pagination-right">
+      <span />
+    </slot>
   </div>
 </template>
 

--- a/packages/components/pagination/src/type.ts
+++ b/packages/components/pagination/src/type.ts
@@ -5,7 +5,7 @@ export interface PlusPaginationSelfProps {
   modelValue?: PageInfo
   total?: number
   pageSizeList?: number[]
-  align?: 'left' | 'right'
+  align?: 'left' | 'right' | 'center'
 }
 
 export type PlusPaginationProps = PlusPaginationSelfProps &

--- a/packages/theme-chalk/src/pagination.scss
+++ b/packages/theme-chalk/src/pagination.scss
@@ -5,4 +5,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 0;
+
+  &--center {
+    justify-content: space-between;
+    
+    .el-pagination {
+      margin: 0 auto;
+    }
+  }
 }


### PR DESCRIPTION
Add center alignment support and examples
<img width="2540" height="902" alt="image" src="https://github.com/user-attachments/assets/f8eb92b9-0255-41a8-a48e-017f61cb4c34" />
