### PR TITLE
Quality: Deprecated `optimizeDeps.disabled` may be silently ignored in Vite 5+

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import VueJsx from '@vitejs/plugin-vue-jsx'
 export default defineConfig({
   plugins: [Vue(), VueJsx()],
   optimizeDeps: {
-    disabled: true
+    noDiscovery: true
   },
   test: {
     clearMocks: true,


### PR DESCRIPTION
## Problem

`optimizeDeps: { disabled: true }` is deprecated in Vite 5 (used by Vitest 1.x+). The replacement is `optimizeDeps: { noDiscovery: true }`. As Vite evolves, the old property may be silently ignored, causing dependency pre-bundling to unexpectedly activate during test runs. This can lead to stale/incorrect module resolution in tests, producing false passes or confusing failures that are hard to debug.


**Severity**: `medium`
**File**: `vitest.config.ts`

## Solution

Replace:
  optimizeDeps: {
    disabled: true
  },
With:
  optimizeDeps: {
    noDiscovery: true
  },


## Changes

- `vitest.config.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
